### PR TITLE
fix: prevent popup disappearing

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -15,24 +15,10 @@
 			"outFiles": [
 				"${workspaceFolder}/out/**/*.js"
 			],
-			"preLaunchTask": "${defaultBuildTask}",
-
+			
 			"env": {
 				"TEST_DEVWORKSPACE_NAME": "remote-plugin-runner"
 			}
-		},
-		{
-			"name": "Extension Tests",
-			"type": "extensionHost",
-			"request": "launch",
-			"args": [
-				"--extensionDevelopmentPath=${workspaceFolder}",
-				"--extensionTestsPath=${workspaceFolder}/out/test/suite/index"
-			],
-			"outFiles": [
-				"${workspaceFolder}/out/test/**/*.js"
-			],
-			"preLaunchTask": "${defaultBuildTask}"
 		}
 	]
 }

--- a/src/command/new-environment-variable.ts
+++ b/src/command/new-environment-variable.ts
@@ -40,7 +40,7 @@ export class NewEnvironmentVariableImpl implements NewEnvironmentVariable {
             const environmentVariable = await this.defineEnvironmentVariable();
             if (environmentVariable) {
                 // update Devfile, show a popup with proposal to open the Devfile
-                await this.saveDevfile.onDidDevfileUpdate(`Environmane '${environmentVariable.name}' has been created successfully`);
+                await this.saveDevfile.onDidDevfileUpdate(`Environment variable '${environmentVariable.name}' has been created successfully`);
                 return true;
             }
 

--- a/src/devfile-extension.ts
+++ b/src/devfile-extension.ts
@@ -17,6 +17,28 @@ import { initBindings } from './bindings';
 import { InstallYaml } from './command/install-yaml';
 
 export async function activate(context: vscode.ExtensionContext): Promise<void> {
+    // Due to the bug in the upstream https://github.com/microsoft/vscode/issues/214787 it is not possible to show
+    // several sequential popups. To prevent popup disappear it needs to add a small delay between two popups.
+
+    // Keep the original functions
+    const _showQuickPick = vscode.window.showQuickPick;
+    const _showInputBox = vscode.window.showInputBox;
+    
+    // Replace with functions with a small delay 
+    Object.assign(vscode.window, {
+        showQuickPick: async (items, options, token) => {
+            const result = await _showQuickPick(items, options, token);
+            await new Promise(resolve => setTimeout(resolve, 300));
+            return result;
+        },
+
+        showInputBox: async (options, token) => {
+            const result = await _showInputBox(options, token);
+            await new Promise(resolve => setTimeout(resolve, 300));
+            return result;
+        }
+    });
+
     const container = initBindings();
     container.get(DevfileExtensionImpl).start(context);
 }


### PR DESCRIPTION
Adds a workaround to prevent popup disappear.
An issue in the upstream describing the problem https://github.com/microsoft/vscode/issues/214787

We should remove the code from `activate()` function in `devfile-extension.ts` file after fixing the upstream issue.

How to test:

- create a workspace using this repository and the editor quay.io/vgulyy/che-code:without-devfile-walkthrough-extension
- install node dependencies
- in a terminal run `npm run watch`
- Go to `Run and Debug` view and run the extension
- add few environment variables, etc.
