### PR TITLE
fix: Use `secrets.RELEASE_GITHUB_TOKEN` instead of `secrets.GITHUB_TOKEN`

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -52,7 +52,7 @@ jobs:
         if: ${{ inputs.publishToMarketPlace == 'true' && inputs.publishToOVSX == 'true' }}
         uses: "marvinpinto/action-automatic-releases@919008cf3f741b179569b7a6fb4d8860689ab7f0"
         with:
-          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          repo_token: "${{ secrets.RELEASE_GITHUB_TOKEN }}"
           automatic_release_tag: "v${{ env.EXT_VERSION }}"
           title: "${{ env.EXT_VERSION }}"
           draft: true


### PR DESCRIPTION
### What does this PR do
It is forbidden to have secrets starting from `GITHUB`.
So, this PR renames `GITHUB_TOKEN` secrets with `RELEASE_GITHUB_TOKEN`